### PR TITLE
automatically set cluster radii based on first seen data

### DIFF
--- a/torch_dvf/transforms.py
+++ b/torch_dvf/transforms.py
@@ -18,6 +18,7 @@ class PointCloudHierarchy():
         self.rel_sampling_ratios = rel_sampling_ratios
         self.interp_simplex = interp_simplex
 
+        self.cluster_radii_arg = cluster_radii  # for "__repr__()"
         self.cluster_radii = cluster_radii if cluster_radii else [None] * len(rel_sampling_ratios)
 
         self.dim_interp_simplex = {'triangle': 2, 'tetrahedron': 3}[interp_simplex]
@@ -58,7 +59,7 @@ class PointCloudHierarchy():
         repr_str = "{}(rel_sampling_ratios={}, cluster_radii={}, interp_simplex={})".format(
             self.__class__.__name__,
             self.rel_sampling_ratios,
-            self.cluster_radii,
+            self.cluster_radii_arg,
             self.interp_simplex
         )
 

--- a/torch_dvf/transforms.py
+++ b/torch_dvf/transforms.py
@@ -1,3 +1,4 @@
+from typing import Tuple, Optional
 import torch_geometric as pyg
 from .data import Data
 import torch
@@ -9,12 +10,12 @@ class PointCloudHierarchy():
     Interpolation from the coarse to the fine scales. For correct batching, "torch_geometric.data.Data.__inc__()" has to be overridden.
 
     Args:
-        rel_sampling_ratios (tuple): relative ratios for successive farthest point sampling
+        rel_sampling_ratios (Tuple[float]): relative ratios for successive farthest point sampling
         interp_simplex (str): reference simplex for interpolation ('triangle' or 'tetrahedron')
-        cluster_radii(tuple, optional): radii for spherical clusters, estimated from first seen data if None (default: None)
+        cluster_radii (Tuple[float], optional): radii for spherical clusters, estimated from first seen data if None (default: None)
     """
 
-    def __init__(self, rel_sampling_ratios: tuple, interp_simplex: str, cluster_radii=None):
+    def __init__(self, rel_sampling_ratios: Tuple[float], interp_simplex: str, cluster_radii: Optional[Tuple[float]] = None):
         self.rel_sampling_ratios = rel_sampling_ratios
         self.interp_simplex = interp_simplex
 
@@ -56,11 +57,11 @@ class PointCloudHierarchy():
 
     def __repr__(self) -> str:
 
-        repr_str = "{}(rel_sampling_ratios={}, cluster_radii={}, interp_simplex={})".format(
+        repr_str = "{}(rel_sampling_ratios={}, interp_simplex={}, cluster_radii={})".format(
             self.__class__.__name__,
             self.rel_sampling_ratios,
-            self.cluster_radii_arg,
-            self.interp_simplex
+            self.interp_simplex,
+            self.cluster_radii_arg
         )
 
         return repr_str


### PR DESCRIPTION
Setting the cluster radii for the pooling can be extremely annoying, so I am adding the option to let them be estimated from the first processed point cloud.