### PR TITLE
option to use running stats for batch normalisation in MLP

### DIFF
--- a/torch_dvf/models.py
+++ b/torch_dvf/models.py
@@ -13,6 +13,7 @@ class PointNet(torch.nn.Module):
         num_output_channels: int,
         num_hierarchies: int,
         num_latent_channels: int,
+        use_running_stats_in_norm: bool = False
     ):
         super().__init__()
 
@@ -25,6 +26,7 @@ class PointNet(torch.nn.Module):
                     (num_input_channels + 3, num_latent_channels, num_latent_channels),
                     plain_last=False,
                     use_norm_in_first=False,
+                    use_running_stats_in_norm=use_running_stats_in_norm,
                 )
             )
         )
@@ -37,6 +39,7 @@ class PointNet(torch.nn.Module):
                     num_output_channels,
                 ),
                 use_norm_in_first=False,
+                use_running_stats_in_norm=use_running_stats_in_norm,
             ),
         )
 
@@ -50,6 +53,7 @@ class PointNet(torch.nn.Module):
                             num_latent_channels,
                         ),
                         plain_last=False,
+                        use_running_stats_in_norm=use_running_stats_in_norm,
                     )
                 )
             )
@@ -60,7 +64,8 @@ class PointNet(torch.nn.Module):
                         2 * num_latent_channels,
                         *[num_latent_channels] * 2,
                         num_latent_channels,
-                    )
+                    ),
+                    use_running_stats_in_norm=use_running_stats_in_norm,
                 ),
             )
 

--- a/torch_dvf/nn/mlp.py
+++ b/torch_dvf/nn/mlp.py
@@ -9,6 +9,7 @@ class MLP(torch.nn.Module):
         num_channels: tuple,
         plain_last: bool = True,
         use_norm_in_first: bool = True,
+        use_running_stats_in_norm: bool = False,
     ):
         super().__init__()
 
@@ -18,7 +19,7 @@ class MLP(torch.nn.Module):
 
         self.linear_layers.append(Linear(*num_channels[:2]))
         self.norm_layers.append(
-            BatchNorm1d(num_channels[1], track_running_stats=False)
+            BatchNorm1d(num_channels[1], track_running_stats=use_running_stats_in_norm)
             if use_norm_in_first
             else Identity()
         )
@@ -29,7 +30,9 @@ class MLP(torch.nn.Module):
         ):
             self.linear_layers.append(Linear(num_channels_in, num_channels_out))
             self.norm_layers.append(
-                BatchNorm1d(num_channels_out, track_running_stats=False)
+                BatchNorm1d(
+                    num_channels_out, track_running_stats=use_running_stats_in_norm
+                )
             )
             self.activations.append(ReLU())
 
@@ -40,7 +43,9 @@ class MLP(torch.nn.Module):
             self.activations.append(Identity())
         else:
             self.norm_layers.append(
-                BatchNorm1d(num_channels[-1], track_running_stats=False)
+                BatchNorm1d(
+                    num_channels[-1], track_running_stats=use_running_stats_in_norm
+                )
             )
             self.activations.append(ReLU())
 


### PR DESCRIPTION
I recently observed using running statistics boosting performance. Earlier I observed this being detrimental, so I am adding an option with default `False`.